### PR TITLE
support for older jinja2 in installer #5501

### DIFF
--- a/installer/roles/kubernetes/tasks/openshift.yml
+++ b/installer/roles/kubernetes/tasks/openshift.yml
@@ -55,14 +55,14 @@
   set_fact:
     kube_cluster: |
       {{ (kube_config.contexts |
-          selectattr("name", "equalto", current_kube_context) |
+          selectattr("name", "match", current_kube_context) |
           list)[0].context.cluster }}
 
 - name: Find server for current context
   set_fact:
     kube_server: |
       {{ (kube_config.clusters |
-          selectattr("name", "equalto", kube_cluster|trim) |
+          selectattr("name", "match", kube_cluster|trim) |
           list)[0].cluster.server }}
 
 - name: Get kube version from api server


### PR DESCRIPTION
##### SUMMARY
Fix for issue #5501

Support older versions of jinja2 e.g. in RHEL 7 in the Openshift installer
equalto is not available, so change it to match
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
>=9.0.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
